### PR TITLE
DEV-190 - UR, Referrer, and PCount Improvements

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,5 +8,13 @@
   <body>
     <h1>Hello</h1>
     <script type="module" src="/src/main.ts"></script>
+    <a href="/page2.html">Page 2 (natural)</a>
+    <a href="/page3.html">Page 3 (natural)</a>
+    <hr>
+    <a href="#/page2">Page 2 (hash)</a>
+    <a href="#/page3">Page 3 (hash)</a>
+    <hr>
+    <button onclick="window.history.pushState({ url: '/page2' }, '', '/page2')">Page 2 (history)</button>
+    <button onclick="window.history.pushState({ url: '/page3' }, '', '/page3')">Page 3 (history)</button>
   </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@99devco/analytics",
-  "version": "1.1.1",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@99devco/analytics",
-      "version": "1.1.1",
+      "version": "2.0.0",
       "license": "MIT",
       "devDependencies": {
         "rimraf": "^5.0.10",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@99devco/analytics",
   "description": "A privacy and security focused Typescript/JavaScript library for tracking website traffic for only $1 per month.",
-  "version": "1.1.1",
+  "version": "2.0.0",
   "private": false,
   "repository": {
     "type": "git",

--- a/src/analytics-script.ts
+++ b/src/analytics-script.ts
@@ -16,15 +16,14 @@ declare global {
 const script = document.currentScript || document.querySelector("script[src*='99dev'][data-site-uuid]");
 const uuid = script?.getAttribute("data-site-uuid") || "";
 const apiUrl = script?.getAttribute("data-api-url") || "https://api.99.dev";
-const navType = script?.getAttribute("data-watch") || "history";
+const navType = script?.getAttribute("data-watch") || "natural";
 
 // Call the analytics library
 analytics.init({
   uuid,
-  navType: navType as "hash" | "history",
+  navType: navType as "natural" | "hash" | "history",
   apiUrl,
 });
-analytics.watch();
 
 // Expose the analytics library as a global variable
 window.nndev = analytics;

--- a/src/analytics-script.ts
+++ b/src/analytics-script.ts
@@ -17,12 +17,18 @@ const script = document.currentScript || document.querySelector("script[src*='99
 const uuid = script?.getAttribute("data-site-uuid") || "";
 const apiUrl = script?.getAttribute("data-api-url") || "https://api.99.dev";
 const navType = script?.getAttribute("data-watch") || "natural";
+const debug = !!script?.getAttribute("data-debug") || false;
+const trackPageRefreshes = !!script?.getAttribute("data-track-page-refreshes") || false;
+const normalizeUrls = !!script?.getAttribute("data-normalize-urls") || true;
 
 // Call the analytics library
 analytics.init({
   uuid,
   navType: navType as "natural" | "hash" | "history",
   apiUrl,
+  debug,
+  trackPageRefreshes,
+  normalizeUrls
 });
 
 // Expose the analytics library as a global variable

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -8,12 +8,26 @@
  * ```ts
  * import * as analytics from '@99devco/analytics';
  * 
- * // Initialize the analytics and watch for navigation changes
+ * // Initialize the analytics - minimal example
  * analytics.init('your-site-uuid')
- * const unwatcher = analytics.watch();
  * 
- * // Stop watching for navigation changes
- * unwatcher();
+ * // Initialize the analytics - minimal example for hash or history navigation
+ * // This automatically adds a Hash or History API watcher.
+ * analytics.init('your-site-uuid', {
+ *   navType: 'hash', // or 'history'
+ * });
+ * 
+ * // Initialize the analytics with all available options
+ * analytics.init({
+ *   uuid: 'your-site-uuid',
+ *   apiUrl: 'https://api.99.dev',
+ *   navType: 'hash',
+ *   recordView: false,
+ *   trackPageRefreshes: true,
+ *   normalizeUrls: false,
+ *   debug: true,
+ * });
+ * 
  * 
  * ```
  */

--- a/src/components/config.ts
+++ b/src/components/config.ts
@@ -10,7 +10,7 @@ export interface AnalyticsConfig {
   /** Unique identifier for your site */
   uuid: string,
   /** Navigation type to watch for page changes */
-  navType: "history" | "hash",
+  navType: "natural" | "history" | "hash",
   /** API endpoint for analytics data */
   apiUrl: string,
   /** Whether to normalize URLS to remove trailing slashes, file extensions, and query parameters */
@@ -20,7 +20,7 @@ export interface AnalyticsConfig {
 /** Default configuration values */
 let config:AnalyticsConfig = {
   uuid: "",
-  navType: "history",
+  navType: "natural",
   apiUrl: "https://api.99.dev",
   normalizeUrls: true,
 };
@@ -29,8 +29,9 @@ let config:AnalyticsConfig = {
  * Updates the analytics configuration with new values
  * @param newConfig - Partial configuration object containing values to update
  */
-export const setConfig = (newConfig:Partial<AnalyticsConfig>) => {
+export const setConfig = (newConfig:Partial<AnalyticsConfig>):AnalyticsConfig => {
   config = { ...config, ...newConfig };
+  return config;
 };
 
 /**

--- a/src/components/config.ts
+++ b/src/components/config.ts
@@ -15,6 +15,8 @@ export interface AnalyticsConfig {
   apiUrl: string,
   /** Whether to normalize URLS to remove trailing slashes, file extensions, and query parameters */
   normalizeUrls: boolean,
+  /** Whether to track page refreshes as views */
+  trackPageRefreshes: boolean,
 }
 
 /** Default configuration values */
@@ -23,6 +25,7 @@ let config:AnalyticsConfig = {
   navType: "natural",
   apiUrl: "https://api.99.dev",
   normalizeUrls: true,
+  trackPageRefreshes: false,
 };
 
 /**

--- a/src/components/config.ts
+++ b/src/components/config.ts
@@ -17,6 +17,8 @@ export interface AnalyticsConfig {
   normalizeUrls: boolean,
   /** Whether to track page refreshes as views */
   trackPageRefreshes: boolean,
+  /** Whether to debug logs */
+  debug: boolean,
 }
 
 /** Default configuration values */
@@ -26,6 +28,7 @@ let config:AnalyticsConfig = {
   apiUrl: "https://api.99.dev",
   normalizeUrls: true,
   trackPageRefreshes: false,
+  debug: false,
 };
 
 /**

--- a/src/components/config.ts
+++ b/src/components/config.ts
@@ -13,6 +13,8 @@ export interface AnalyticsConfig {
   navType: "history" | "hash",
   /** API endpoint for analytics data */
   apiUrl: string,
+  /** Whether to normalize URLS to remove trailing slashes, file extensions, and query parameters */
+  normalizeUrls: boolean,
 }
 
 /** Default configuration values */
@@ -20,6 +22,7 @@ let config:AnalyticsConfig = {
   uuid: "",
   navType: "history",
   apiUrl: "https://api.99.dev",
+  normalizeUrls: true,
 };
 
 /**

--- a/src/components/get-url.ts
+++ b/src/components/get-url.ts
@@ -74,7 +74,7 @@ export default function getURL() {
       url = ["/", url].join("");
 
     // Remove trailing slash
-    if (url[url.length - 1] === "/")
+    if (url.length > 1 && url[url.length - 1] === "/")
       url = url.slice(0, -1);
 
     // Remove trailing file extension

--- a/src/components/get-url.ts
+++ b/src/components/get-url.ts
@@ -39,7 +39,7 @@ import { getConfig } from "./config";
  * ```
  */
 export default function getURL() {
-  const { navType } = getConfig();
+  const { navType, normalizeUrls } = getConfig();
 
   // Handle 99dev Page Meta
   const metaTag:HTMLMetaElement|null = document.querySelector('meta[name="99dev-page"]');
@@ -51,21 +51,36 @@ export default function getURL() {
   if (canonicalLink && canonicalLink.href)
       return canonicalLink.href.replace(window.location.origin,"");
 
+  let url = "";
+
   // Handle Hash
   if (navType === "hash")
-    return window.location.hash.substring(1).split("?")[0]; // Drop the leading "#" and any query parameters
-
+    url = window.location.hash.substring(1); // Drop the leading "#" and any query parameters
   // Handle History API
-  if (navType === "history") {
-    // Check for custom URL in history state
-    const state = window.history.state;
-    if (state && state.url) {
-      return state.url;
-    }
-    
-    return window.location.pathname;
+  else  if (navType === "history" && window.history.state && window.history.state.url)
+    url = window.history.state.url;
+  // Default fallback
+  else
+    url = window.location.pathname;
+
+  // URL formatting
+  if (normalizeUrls) {
+
+    // Remove query parameters
+    url = url.split("?")[0];
+
+    // Ensure leading slash is present
+    if (url[0] !== "/")
+      url = ["/", url].join("");
+
+    // Remove trailing slash
+    if (url[url.length - 1] === "/")
+      url = url.slice(0, -1);
+
+    // Remove trailing file extension
+    if (url.endsWith(".html"))
+      url = url.slice(0, -5);
   }
 
-  // Default fallback
-  return window.location.pathname;
+  return url;
 }

--- a/src/components/init.ts
+++ b/src/components/init.ts
@@ -27,7 +27,7 @@ export interface InitOptions extends Partial<AnalyticsConfig> {
   /** Whether to normalize URLS to remove trailing slashes, file extensions, and query parameters. Default is true. */
   normalizeUrls?: boolean;
 
-  /** Whether to add a watcher to the analytics library. Default is true. */
+  /** Whether to add a watcher to the analytics library. Default is true if Hash or History navType is used. */
   addWatcher?: boolean;
 }
 
@@ -68,40 +68,27 @@ export interface CompleteInitOptions extends InitOptions {
  * ```
  */
 export function init(uuidOrConfig: string | CompleteInitOptions, options?: InitOptions): void {
-  let settings: Partial<AnalyticsConfig>;
+  let settings: Partial<InitOptions>;
   
   if (typeof uuidOrConfig === 'string') {
     // If first parameter is a string, use it as UUID
-    settings = { uuid: uuidOrConfig };
-    if (options) {
-      if (options.navType) settings.navType = options.navType;
-      if (options.apiUrl) settings.apiUrl = options.apiUrl;
-    }
+    settings = options ? options : {};
+    settings.uuid = uuidOrConfig;
   } else {
     // If first parameter is options object
-    settings = { uuid: uuidOrConfig.uuid };
-    if (uuidOrConfig.navType) settings.navType = uuidOrConfig.navType;
-    if (uuidOrConfig.apiUrl) settings.apiUrl = uuidOrConfig.apiUrl;
+    settings = uuidOrConfig
   }
 
   // cache the config values
   const config = setConfig(settings);
 
   // record the current page, unless the options toggle it off
-  const shouldRecordView = typeof uuidOrConfig === 'string' 
-    ? options?.recordView !== false
-    : uuidOrConfig.recordView !== false;
-
-  if (shouldRecordView) {
+  if (settings.recordView !== false) {
     recordView();
   }
 
   // add a has or history watcher, unless the options toggle it off
-  const shouldAddWatcher = typeof uuidOrConfig === 'string' 
-    ? options?.addWatcher !== false
-    : uuidOrConfig.addWatcher !== false;
-
-  if (shouldAddWatcher && (config.navType === "hash" || config.navType === "history")) {
+  if (settings.addWatcher !== false && (config.navType === "hash" || config.navType === "history")) {
     watch();
   }
 }

--- a/src/components/init.ts
+++ b/src/components/init.ts
@@ -9,6 +9,7 @@ import {
 } from "./config";
 import { recordView } from "./record-view";
 import { watch } from "./watch";
+import { log } from "./logger";
 
 /**
  * Configuration options for initializing the analytics library.
@@ -81,6 +82,8 @@ export function init(uuidOrConfig: string | CompleteInitOptions, options?: InitO
 
   // cache the config values
   const config = setConfig(settings);
+
+  log(JSON.stringify({config}, null, 2));
 
   // record the current page, unless the options toggle it off
   if (settings.recordView !== false) {

--- a/src/components/init.ts
+++ b/src/components/init.ts
@@ -22,6 +22,9 @@ export interface InitOptions extends Partial<AnalyticsConfig> {
 
   /** The navigation type to use. Default is 'history'. */
   navType?: "hash" | "history";
+
+  /** Whether to normalize URLS to remove trailing slashes, file extensions, and query parameters. Default is true. */
+  normalizeUrls?: boolean;
 }
 
 /**

--- a/src/components/init.ts
+++ b/src/components/init.ts
@@ -22,8 +22,8 @@ export interface InitOptions extends Partial<AnalyticsConfig> {
   /** The API URL to record traffic to. Default is https://api.99.dev. */
   apiUrl?: string;
 
-  /** The navigation type to use. Default is 'history'. */
-  navType?: "hash" | "history";
+  /** The navigation type to use. Default is 'natural'. */
+  navType?: "natural" | "history" | "hash";
 
   /** Whether to normalize URLS to remove trailing slashes, file extensions, and query parameters. Default is true. */
   normalizeUrls?: boolean;

--- a/src/components/init.ts
+++ b/src/components/init.ts
@@ -8,6 +8,7 @@ import {
   type AnalyticsConfig
 } from "./config";
 import { recordView } from "./record-view";
+import { watch } from "./watch";
 
 /**
  * Configuration options for initializing the analytics library.
@@ -25,6 +26,9 @@ export interface InitOptions extends Partial<AnalyticsConfig> {
 
   /** Whether to normalize URLS to remove trailing slashes, file extensions, and query parameters. Default is true. */
   normalizeUrls?: boolean;
+
+  /** Whether to add a watcher to the analytics library. Default is true. */
+  addWatcher?: boolean;
 }
 
 /**
@@ -81,7 +85,7 @@ export function init(uuidOrConfig: string | CompleteInitOptions, options?: InitO
   }
 
   // cache the config values
-  setConfig(settings);
+  const config = setConfig(settings);
 
   // record the current page, unless the options toggle it off
   const shouldRecordView = typeof uuidOrConfig === 'string' 
@@ -90,5 +94,14 @@ export function init(uuidOrConfig: string | CompleteInitOptions, options?: InitO
 
   if (shouldRecordView) {
     recordView();
+  }
+
+  // add a has or history watcher, unless the options toggle it off
+  const shouldAddWatcher = typeof uuidOrConfig === 'string' 
+    ? options?.addWatcher !== false
+    : uuidOrConfig.addWatcher !== false;
+
+  if (shouldAddWatcher && (config.navType === "hash" || config.navType === "history")) {
+    watch();
   }
 }

--- a/src/components/logger.ts
+++ b/src/components/logger.ts
@@ -1,0 +1,30 @@
+/**
+ * @category Core
+ */
+
+import { getConfig } from "./config";
+
+/**
+ * Logs a message to the console if debug mode is enabled in the configuration.
+ * 
+ * This function checks the debug setting from the analytics configuration and only
+ * outputs the message to the console if debug mode is turned on. This allows for
+ * conditional logging that can be controlled via the analytics configuration.
+ * 
+ * @param message - The message to log to the console
+ * 
+ * @example
+ * ```typescript
+ * // Log a debug message
+ * log("Analytics initialized successfully");
+ * 
+ * // Log with dynamic content
+ * log(`Page view recorded for URL: ${currentUrl}`);
+ * ```
+ */
+export function log(message: string): void {
+  const { debug } = getConfig();
+  if (debug) {
+    console.log(message);
+  }
+}

--- a/src/components/record-view.ts
+++ b/src/components/record-view.ts
@@ -5,6 +5,7 @@
 import { getConfig } from "./config";
 import getURL from "./get-url";
 import objToQps from "./obj-to-qps";
+import { log } from "./logger";
 
 /**
  * Records a page view in the analytics system.
@@ -35,8 +36,11 @@ export function recordView (url?:string, referrer?:string):void {
 
   // Ignore page refreshes if the config is set to not track them
   if (!trackPageRefreshes && pageView.url === pageView.referrer) {
+    log("Page refresh detected, skipping page view record.");
     return;
   }
+
+  log(JSON.stringify({pageView}, null, 2));
 
   // Cache the pCount / Page Count for subsequent page view saves.
   cachePCount(pageView.pcount);
@@ -45,6 +49,10 @@ export function recordView (url?:string, referrer?:string):void {
   cacheReferrer(pageView.url);
 
   // Load the tracking pixel / send the analytics event
+  if (!uuid) {
+    log("No UUID found, skipping tracking pixel load.");
+    return;
+  }
   const trkpxl = document.createElement("img");
   trkpxl.setAttribute("alt", "");
   trkpxl.setAttribute("aria-hidden", "true");

--- a/src/components/record-view.ts
+++ b/src/components/record-view.ts
@@ -25,17 +25,19 @@ export function recordView (url?:string, referrer?:string):void {
   const urlToRecord = url || getURL();
   const { uuid, apiUrl } = getConfig();
 
+  const pageView = {
+    url: urlToRecord,
+    referrer: referrer || getReferrer(),
+    timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+    pcount: getPCount(),
+  };
+
   // Load the tracking pixel / send the analytics event
   const trkpxl = document.createElement("img");
   trkpxl.setAttribute("alt", "");
   trkpxl.setAttribute("aria-hidden", "true");
   trkpxl.style.position = "absolute";
-  trkpxl.src = encodeURI(`${apiUrl}/mian/${uuid}/tpxl.gif?${objToQps({
-    url: urlToRecord,
-    referrer: referrer || getReferrer(),
-    timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
-    pcount: getPCount(),
-  })}`);
+  trkpxl.src = encodeURI(`${apiUrl}/mian/${uuid}/tpxl.gif?${objToQps(pageView)}`);
   trkpxl.addEventListener("load", function () {
     trkpxl.parentNode?.removeChild(trkpxl);
   });
@@ -51,7 +53,6 @@ export function recordView (url?:string, referrer?:string):void {
  */
 function getReferrer():string {
   const split = window.document.referrer.split(window.location.origin);
-  console.log(split[split.length-1]);
   return split[split.length-1] || "";
 }
 

--- a/src/components/watch.ts
+++ b/src/components/watch.ts
@@ -26,7 +26,6 @@ const unwatchers:Array<()=>any> = [];
  * unwatcher();
  * ```
  * 
- * @param navType - Optional navigation type to use ("hash" or "history")
  * @returns A function that removes the watcher when called
  */
 export function watch():()=>void {

--- a/src/components/watch.ts
+++ b/src/components/watch.ts
@@ -4,8 +4,7 @@
  */
 
 // Include external dependencies
-import { getConfig, setConfig } from "./config";
-import getURL from "./get-url";
+import { getConfig } from "./config";
 import { recordView } from "./record-view";
 
 /** 
@@ -21,13 +20,7 @@ const unwatchers:Array<()=>any> = [];
  * @example
  * ```typescript
  * // Start watching using default navigation type from init()
- * watch();
- * 
- * // Start watching hash-based navigation
- * const unwatcher = watch("hash");
- * 
- * // Start watching History API navigation
- * const unwatcher = watch("history");
+ * const unwatcher = watch();
  * 
  * // Stop watching
  * unwatcher();
@@ -36,14 +29,9 @@ const unwatchers:Array<()=>any> = [];
  * @param navType - Optional navigation type to use ("hash" or "history")
  * @returns A function that removes the watcher when called
  */
-export function watch(navType?: "hash" | "history"):()=>void {
-  // Set or get the navigation type configuration
-  if (navType) {
-    setConfig({ navType });
-  }
-  else {
-    navType = getConfig().navType;
-  }
+export function watch():()=>void {
+
+  const { navType } = getConfig();
 
   let unwatcher = () => {};
 

--- a/src/components/watch.ts
+++ b/src/components/watch.ts
@@ -48,15 +48,9 @@ export function watch(navType?: "hash" | "history"):()=>void {
   let unwatcher = () => {};
 
   // Create a closure to maintain referrer state and handle URL changes
-  const handleUrlChange = (() => {
-    // Store the initial URL as the first referrer
-    let referrer = getURL();
-    return () => {
-      const url = getURL();
-      recordView(url, referrer);
-      referrer = url;
-    };
-  })();
+  const handleUrlChange = function () {
+    recordView();
+  }
 
   if (navType === "hash") {
     // Hash-based navigation: Watch for hashchange events

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,6 +12,6 @@ import * as analytics from "./analytics";
 
 analytics.init({
   uuid: "baac2fb6-25b2-4ea6-abc7-2619dc064ffa",
-  navType: "history",
+  // navType: "history",
   apiUrl: "http://localhost:3000",
 });

--- a/src/main.ts
+++ b/src/main.ts
@@ -15,4 +15,3 @@ analytics.init({
   navType: "history",
   apiUrl: "http://localhost:3000",
 });
-analytics.watch();

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,8 +11,8 @@ It is NOT intended to be used as part of the actual 99dev analytics package.
 import * as analytics from "./analytics";
 
 analytics.init({
-  uuid: "45cb85ab-1e27-4db4-b3e1-468e8a1e32fc",
-  // navType: "hash",
+  uuid: "baac2fb6-25b2-4ea6-abc7-2619dc064ffa",
+  navType: "history",
   apiUrl: "http://localhost:3000",
 });
 analytics.watch();

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,4 +14,5 @@ analytics.init({
   uuid: "baac2fb6-25b2-4ea6-abc7-2619dc064ffa",
   // navType: "history",
   apiUrl: "http://localhost:3000",
+  debug: true,
 });


### PR DESCRIPTION
This PR makes substantial improvements including:

- URL normalization including leading and trailing slashes and file extensions across hash, history, and natural navigation.
- Referrer tracking across hash, history, and natural navigation and forward/backwards navigation.
- Page Count (PCount) tracking across tabs. This now utilizes a combination of Session Storage and Local Storage.
- Debug logging
- Page Refreshes no longer record page views, unless configured to.

This PR also introduces a **Breaking Change**, where `watch()` is automatically applied by the `init()` call if hash or history navigation is applied.