### PR TITLE
Add UTM attribution support and improve test harness

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,9 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>@99dev/browser</title>
+
+    <!-- Include Bootstrap CSS via CDN -->
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-sRIl4kxILFvY47J16cr9ZwB07vP4J8+LH7qKQnuqkuIAvNWLzeN8tE5YBujZqJLB" crossorigin="anonymous">
   </head>
   <body>
     <h1>Navigation Testing</h1>
@@ -24,5 +27,8 @@
     <button onclick="recordEvent('event 2', { prop1: 'value1' })">Event 2 (with props)</button>
     <button onclick="recordEvent('event 3')">Event 3</button>
     <button onclick="recordEvent('event 4')">Event 4</button>
+
+    <!-- Include Bootstrap JS via CDN -->
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/js/bootstrap.bundle.min.js" integrity="sha384-FKyoEForCGlyvwx9Hj09JcYn3nv7wiPVlz7YYwJrWVcXK/BmnVDxM+D2scQbITxI" crossorigin="anonymous"></script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -8,25 +8,108 @@
     <!-- Include Bootstrap CSS via CDN -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-sRIl4kxILFvY47J16cr9ZwB07vP4J8+LH7qKQnuqkuIAvNWLzeN8tE5YBujZqJLB" crossorigin="anonymous">
   </head>
-  <body>
-    <h1>Navigation Testing</h1>
+  <body class="bg-body-tertiary">
+    <main class="container py-4 py-md-5">
+      <div class="row justify-content-center">
+        <div class="col-12 col-lg-10">
+          <header class="mb-4">
+            <h1 class="h2 mb-1">@99dev/browser Test Harness</h1>
+            <p class="text-body-secondary mb-0">Use this page to test navigation and event tracking behavior.</p>
+          </header>
+
+          <div class="card shadow-sm mb-4">
+            <div class="card-body">
+              <h2 class="h5 card-title mb-3">Tracker UUID</h2>
+              <form id="uuid-form" class="row g-3 align-items-end">
+                <div class="col-12 col-md">
+                  <label for="uuid-input" class="form-label">Site UUID</label>
+                  <input id="uuid-input" name="uuid" class="form-control" type="text" placeholder="Enter UUID for testing" autocomplete="off" required>
+                  <div class="form-text">This value is stored in local storage and used by <code>main.ts</code>.</div>
+                </div>
+                <div class="col-12 col-md-auto">
+                  <button type="submit" class="btn btn-primary w-100">Save and Refresh</button>
+                </div>
+              </form>
+            </div>
+          </div>
+
+          <div class="card shadow-sm mb-4">
+            <div class="card-body">
+              <h2 class="h5 card-title mb-3">Navigation Testing</h2>
+              <p class="text-body-secondary small mb-3">
+                Use these controls to test how tracking behaves for full page loads, hash-only changes, and History API updates.
+              </p>
+              <div class="d-flex flex-wrap gap-2 mb-3">
+                <a class="btn btn-outline-primary" href="/page2.html">Natural: page2.html (full reload)</a>
+                <a class="btn btn-outline-primary" href="/page3.html">Natural: page3.html (full reload)</a>
+              </div>
+              <div class="d-flex flex-wrap gap-2 mb-3">
+                <a class="btn btn-outline-secondary" href="#/page2">Hash: #/page2 (no reload)</a>
+                <a class="btn btn-outline-secondary" href="#/page3">Hash: #/page3 (no reload)</a>
+              </div>
+              <div class="d-flex flex-wrap gap-2">
+                <button type="button" class="btn btn-outline-dark" onclick="window.history.pushState({ url: '/page2' }, '', '/page2')">History API: /page2 (pushState)</button>
+                <button type="button" class="btn btn-outline-dark" onclick="window.history.pushState({ url: '/page3' }, '', '/page3')">History API: /page3 (pushState)</button>
+              </div>
+            </div>
+          </div>
+
+          <div class="card shadow-sm mb-4">
+            <div class="card-body">
+              <h2 class="h5 card-title mb-3">UTM Parameter Testing</h2>
+              <p class="text-body-secondary small mb-3">
+                Each button reloads this page with preset UTM query parameters so you can verify campaign attribution capture.
+              </p>
+              <div class="d-flex flex-wrap gap-2 mb-3">
+                <a class="btn btn-outline-info" href="/?utm_source=newsletter&utm_medium=email&utm_campaign=spring_launch&utm_content=hero_cta&utm_term=analytics_sdk">UTM Set A: Newsletter Email</a>
+                <a class="btn btn-outline-info" href="/?utm_source=google&utm_medium=cpc&utm_campaign=brand_search&utm_content=text_ad_1&utm_term=analytics+tracking">UTM Set B: Paid Search</a>
+              </div>
+              <div class="d-flex flex-wrap gap-2">
+                <a class="btn btn-outline-info" href="/?utm_source=partner&utm_medium=referral&utm_campaign=integration_launch&utm_content=docs_link&utm_term=fastify">UTM Set C: Partner Referral</a>
+                <a class="btn btn-outline-secondary" href="/">Clear query params (no UTM)</a>
+              </div>
+            </div>
+          </div>
+
+          <div class="card shadow-sm">
+            <div class="card-body">
+              <h2 class="h5 card-title mb-3">Event Testing</h2>
+              <p class="text-body-secondary small mb-3">
+                These buttons call <code>recordEvent(...)</code> with the shown payload. Use your network tab to inspect the queued event payload.
+              </p>
+              <div class="d-flex flex-wrap gap-2">
+                <button type="button" class="btn btn-success" onclick="recordEvent('event 1')">recordEvent("event 1")</button>
+                <button type="button" class="btn btn-success" onclick="recordEvent('event 2', { prop1: 'value1' })">recordEvent("event 2", { prop1: "value1" })</button>
+                <button type="button" class="btn btn-success" onclick="recordEvent('event 3')">recordEvent("event 3")</button>
+                <button type="button" class="btn btn-success" onclick="recordEvent('event 4')">recordEvent("event 4")</button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </main>
+
+    <script>
+      const UUID_STORAGE_KEY = "99dev-test-uuid";
+      const uuidForm = document.getElementById("uuid-form");
+      const uuidInput = document.getElementById("uuid-input");
+      const storedUuid = localStorage.getItem(UUID_STORAGE_KEY) || "";
+
+      if (uuidInput instanceof HTMLInputElement) {
+        uuidInput.value = storedUuid;
+      }
+
+      if (uuidForm && uuidInput instanceof HTMLInputElement) {
+        uuidForm.addEventListener("submit", function (event) {
+          event.preventDefault();
+          const nextUuid = uuidInput.value.trim();
+          localStorage.setItem(UUID_STORAGE_KEY, nextUuid);
+          window.location.reload();
+        });
+      }
+    </script>
+
     <script type="module" src="/src/main.ts"></script>
-    <a href="/page2.html">Page 2 (natural)</a>
-    <a href="/page3.html">Page 3 (natural)</a>
-    <hr>
-    <a href="#/page2">Page 2 (hash)</a>
-    <a href="#/page3">Page 3 (hash)</a>
-    <hr>
-    <button onclick="window.history.pushState({ url: '/page2' }, '', '/page2')">Page 2 (history)</button>
-    <button onclick="window.history.pushState({ url: '/page3' }, '', '/page3')">Page 3 (history)</button>
-    <hr>
-    <hr>
-    <hr>
-    <h1>Event Testing</h1>
-    <button onclick="recordEvent('event 1')">Event 1</button>
-    <button onclick="recordEvent('event 2', { prop1: 'value1' })">Event 2 (with props)</button>
-    <button onclick="recordEvent('event 3')">Event 3</button>
-    <button onclick="recordEvent('event 4')">Event 4</button>
 
     <!-- Include Bootstrap JS via CDN -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/js/bootstrap.bundle.min.js" integrity="sha384-FKyoEForCGlyvwx9Hj09JcYn3nv7wiPVlz7YYwJrWVcXK/BmnVDxM+D2scQbITxI" crossorigin="anonymous"></script>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@99devco/analytics",
-  "version": "3.1.0",
+  "version": "4.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@99devco/analytics",
-      "version": "3.1.0",
+      "version": "4.0.0",
       "license": "MIT",
       "devDependencies": {
         "rimraf": "^5.0.10",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@99devco/analytics",
   "description": "A privacy and security focused Typescript/JavaScript library for tracking website traffic for only $1 per month.",
-  "version": "3.1.0",
+  "version": "4.0.0",
   "private": false,
   "repository": {
     "type": "git",

--- a/src/components/record-event.ts
+++ b/src/components/record-event.ts
@@ -9,6 +9,7 @@ import { sizeOf } from "./size-of";
 import { uuid } from "./uuid";
 import getURL from "./get-url";
 import { getPCount } from "./pcount";
+import { getUtmParams } from "./utm";
 
 // @ts-ignore
 const version = __VERSION__;
@@ -47,6 +48,16 @@ export interface AnalyticsBatch {
   script_version: string;
   /** Timezone of the client */
   timezone: string;
+  /** UTM source for this session's campaign attribution */
+  utm_source?: string;
+  /** UTM medium for this session's campaign attribution */
+  utm_medium?: string;
+  /** UTM campaign for this session's campaign attribution */
+  utm_campaign?: string;
+  /** UTM term for this session's campaign attribution */
+  utm_term?: string;
+  /** UTM content for this session's campaign attribution */
+  utm_content?: string;
 }
 
 // In-memory queue (not persisted across reloads)
@@ -97,7 +108,8 @@ export function recordEvent(
 /**
  * Sends the queued events to the collector endpoint. Normally triggered by
  * timers or lifecycle hooks, but exposed publicly so apps can flush after
- * critical flows (e.g., before redirecting away).
+ * critical flows (e.g., before redirecting away). Session-cached UTM
+ * parameters are included when available for campaign attribution.
  *
  * @param _force - Present for future behavior toggles; currently unused
  */
@@ -120,6 +132,8 @@ export function flushEvents(_force = false): void {
     transport: "beacon",
     script_version: version,
     timezone: Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC",
+    // Attach session-scoped campaign attribution, independent of event details.
+    ...getUtmParams(),
   };
   for (const e of QUEUE) {
     const test = JSON.stringify({ ...batch, events: [...batch.events, e] });

--- a/src/components/record-view.ts
+++ b/src/components/record-view.ts
@@ -8,6 +8,7 @@ import objToQps from "./obj-to-qps";
 import { log } from "./logger";
 import { getReferrer, referrerStorageKeyActual, referrerStorageKeyRecord } from "./get-referrer";
 import { cachePCount, getPCount } from "./pcount";
+import { getUtmParams } from "./utm";
 
 // @ts-ignore
 const version = __VERSION__;
@@ -15,7 +16,8 @@ const version = __VERSION__;
 /**
  * Records the current page view by collecting the normalized URL, referrer,
  * timezone, SDK version, and calculated page-count, then dispatching a tracking
- * pixel to the configured API endpoint.
+ * pixel to the configured API endpoint. UTM parameters are automatically
+ * included when present in the URL (or recovered from the current session).
  *
  * When called without overrides the function:
  * 1. Reads `{ actualUrl, recordUrl }` from `getURL()` so canonical/meta overrides
@@ -47,12 +49,19 @@ export function recordView (url?:string, referrer?:string):void {
   const { actualReferrer, recordReferrer } = getReferrer();
 
   // Format the Page View data
-  const pageView = {
+  const pageViewBase = {
     url: url || recordUrl,
     referrer: referrer || recordReferrer,
     timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
     pcount: Infinity,
     version
+  };
+
+  // Attach session-cached UTMs to every page view for campaign attribution.
+  const utmParams = getUtmParams();
+  const pageView = {
+    ...pageViewBase,
+    ...utmParams,
   };
 
   // Ignore page refreshes if the config is set to not track them

--- a/src/components/utm.ts
+++ b/src/components/utm.ts
@@ -1,0 +1,111 @@
+/**
+ * @category Utilities
+ */
+
+/**
+ * UTM campaign parameters extracted from the current URL or recovered from
+ * this tab's session cache. All fields are optional.
+ *
+ * @category Utilities
+ */
+export interface UtmParams {
+  utm_source?: string;
+  utm_medium?: string;
+  utm_campaign?: string;
+  utm_term?: string;
+  utm_content?: string;
+}
+
+// Supported UTM keys that can be extracted and cached.
+const UTM_KEYS: Array<keyof UtmParams> = [
+  "utm_source",
+  "utm_medium",
+  "utm_campaign",
+  "utm_term",
+  "utm_content",
+];
+
+// Session cache key used to persist UTMs for the current tab/session.
+const STORAGE_KEY = "99dev_utm";
+
+/**
+ * Reads UTM parameters from the current URL, preferring query-string values on
+ * `window.location.search` over values found in hash-fragment query strings,
+ * and caches fresh values in `sessionStorage` for the rest of the tab session.
+ *
+ * If no UTM values are present in the current URL, previously cached values
+ * are returned (if available).
+ *
+ * @category Core
+ *
+ * @returns UTM parameters from the current URL when present, otherwise cached values.
+ *
+ * @example
+ * ```ts
+ * const utm = getUtmParams();
+ * // { utm_source: "google", utm_campaign: "spring-sale" }
+ * ```
+ */
+export function getUtmParams (): UtmParams {
+  const urlParams = extractUtmFromUrl();
+
+  // Persist fresh URL UTMs for this tab session (last-touch within session).
+  if (Object.keys(urlParams).length > 0) {
+    sessionStorage.setItem(STORAGE_KEY, JSON.stringify(urlParams));
+    return urlParams;
+  }
+
+  // Fall back to previously cached UTMs when the current URL has none.
+  const cached = sessionStorage.getItem(STORAGE_KEY);
+  if (!cached) return {};
+
+  try {
+    const parsed = JSON.parse(cached);
+    if (!parsed || typeof parsed !== "object") return {};
+
+    const normalized: UtmParams = {};
+    for (const key of UTM_KEYS) {
+      if (typeof parsed[key] === "string" && parsed[key] !== "") {
+        normalized[key] = parsed[key];
+      }
+    }
+    return normalized;
+  } catch (_err) {
+    return {};
+  }
+}
+
+/**
+ * Extracts UTM parameters from both standard query params and hash-based query
+ * params (for hash-routed SPAs), then merges with priority for
+ * `window.location.search` when duplicate keys exist.
+ */
+function extractUtmFromUrl (): UtmParams {
+  const fromSearch: UtmParams = {};
+  const fromHash: UtmParams = {};
+
+  // Read standard ad-platform UTMs from the URL search string.
+  const searchParams = new URLSearchParams(window.location.search);
+  for (const key of UTM_KEYS) {
+    const value = searchParams.get(key);
+    if (value) fromSearch[key] = value;
+  }
+
+  // Read UTMs from hash-fragment query strings (e.g. "#/route?utm_source=...").
+  const hash = window.location.hash || "";
+  const hashQueryIndex = hash.indexOf("?");
+  if (hashQueryIndex >= 0) {
+    const hashQuery = hash.slice(hashQueryIndex + 1);
+    const hashParams = new URLSearchParams(hashQuery);
+    for (const key of UTM_KEYS) {
+      const value = hashParams.get(key);
+      if (value) fromHash[key] = value;
+    }
+  }
+
+  // Merge with search-string values taking precedence over hash values.
+  return {
+    ...fromHash,
+    ...fromSearch,
+  };
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,7 +12,7 @@ import * as analytics from "./analytics";
 
 // Initialize the analytics system
 analytics.init({
-  uuid: "2486b5bc-1b13-4616-bbf5-1cf7c92db1ac",
+  uuid: "40d4f9c4-10b1-41d0-aea8-472fcc8be35e",
   // navType: "history",
   apiUrl: "http://localhost:3000",
   debug: true,

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,15 +10,19 @@ It is NOT intended to be used as part of the actual 99dev analytics package.
 // Include our external dependencies!
 import * as analytics from "./analytics";
 
-// Initialize the analytics system
-analytics.init({
-  uuid: "40d4f9c4-10b1-41d0-aea8-472fcc8be35e",
-  // navType: "history",
-  apiUrl: "http://localhost:3000",
-  debug: true,
-});
+const UUID_STORAGE_KEY = "99dev-test-uuid";
+const testUuid = localStorage.getItem(UUID_STORAGE_KEY)?.trim() || "";
+
+// Initialize the analytics system only when a UUID is configured
+if (testUuid) {
+  analytics.init({
+    uuid: testUuid,
+    // navType: "history",
+    apiUrl: "http://localhost:3000",
+    debug: true,
+  });
+}
 
 // Expose the event recorder globally
 (window as any).recordEvent = analytics.recordEvent;
-
 


### PR DESCRIPTION
This PR adds campaign attribution support by parsing UTM params and including them in page-view and event payloads.
It introduces `src/components/utm.ts` and wires it into `record-view` and `record-event` with session-scoped persistence.
It also refreshes the local dev harness (`index.html` and `src/main.ts`) using Bootstrap, explicit test labels, UTM test links, and a localStorage-backed UUID form instead of a hard-coded UUID.
Finally, it bumps the package to v4.0.0 and updates the lockfile.
