### PR TITLE
Fix null appendChild during early analytics init

### DIFF
--- a/src/components/record-view.ts
+++ b/src/components/record-view.ts
@@ -97,7 +97,20 @@ export function recordView (url?:string, referrer?:string):void {
   trkpxl.addEventListener("error", function () {
     trkpxl.parentNode?.removeChild(trkpxl);
   });
-  document.body.appendChild(trkpxl);
+
+  const appendTrackingPixel = function ():boolean {
+    const root = document.body || document.documentElement;
+    if (!root) return false;
+    root.appendChild(trkpxl);
+    return true;
+  };
+
+  // Some integrations initialize before <body> exists (e.g. script in <head>).
+  if (!appendTrackingPixel() && document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", function onDomReady() {
+      appendTrackingPixel();
+    }, { once: true });
+  }
 }
 
 


### PR DESCRIPTION
This PR fixes a runtime error when analytics initializes before the page body exists.

`recordView()` now appends the tracking pixel through a guarded helper that targets `document.body` or `document.documentElement`, and falls back to `DOMContentLoaded` when needed.
This prevents `Cannot read properties of null (reading 'appendChild')` while preserving existing tracking behavior.
